### PR TITLE
Cache Docker Desktop by build number

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_automatic_review.yaml
+++ b/.github/ISSUE_TEMPLATE/1_automatic_review.yaml
@@ -33,3 +33,7 @@ body:
         - label: I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)
     validations:
       required: true
+  - type: markdown
+    attributes:
+      value: |
+        We will contact you if necessary using the email address that is associated with your Docker Hub account.

--- a/.github/workflows/templates/tos-accepted.md
+++ b/.github/workflows/templates/tos-accepted.md
@@ -1,6 +1,6 @@
 :white_check_mark: @{{ .user }} has accepted the terms of service.
 
-The automatic validation for publishing your extension has started, you will see the result in ~10 minutes :hourglass_flowing_sand:.
+The automatic validation of your extension has started, you will see the result in ~10 minutes :hourglass_flowing_sand:.
 
 ---
 See [action]({{ .workflow_url }}) for more details.

--- a/.github/workflows/templates/validation-errored.md
+++ b/.github/workflows/templates/validation-errored.md
@@ -1,0 +1,7 @@
+:x: There was a problem during the validation job.
+
+Someone from the @docker/extensions will have to take a look at this issue.
+We will let you know in this issue when it is fixed.
+
+---
+See [action]({{ .workflow_url }}) for more details.

--- a/.github/workflows/templates/validation-failed.md
+++ b/.github/workflows/templates/validation-failed.md
@@ -1,0 +1,8 @@
+:x: Validation failed with the following errors
+
+> {{ .validation_output }}
+
+Please fix the issues and comment with `/validate` to re-run the validation when you are ready.
+
+---
+See [action]({{ .workflow_url }}) for more details.

--- a/.github/workflows/templates/validation-repository-not-found.md
+++ b/.github/workflows/templates/validation-repository-not-found.md
@@ -1,0 +1,10 @@
+:no_entry_sign: Docker Hub repository name not found.
+
+Please add the following section to the body of the issue with the extension name below it:
+
+```md
+### Docker Hub repository name
+```
+
+---
+See [action]({{ .workflow_url }}) for more details.

--- a/.github/workflows/templates/validation-succeeded.md
+++ b/.github/workflows/templates/validation-succeeded.md
@@ -1,0 +1,18 @@
+:white_check_mark: Validation ended successfully
+
+Yay! The extension [{{ .extension }}](https://open.docker.com/extensions/marketplace?extensionId={{ .extension }}) is valid :tada:.
+
+Now, @docker/extensions will add the `publish/ready` label to the issue which will start the publishing of the extension on the marketplace.
+Once published, this issue will be closed :smile:.
+
+In the meantime, you can answer a couple of questions to tell us how your experience building a Docker Desktop extension was :smiley:: https://forms.gle/88SLHsn2Xb1BgMQ49.
+
+
+<details>
+<summary>Click to see the validation output</summary>
+
+> {{ .validation_output }}
+</details>
+
+---
+See [action]({{ .workflow_url }}) for more details.

--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -16,14 +16,14 @@ env:
   GH_REPO: ${{ github.repository }}
 
 jobs:
-  check:
-    if: github.event.issue.closed == false
+  parse-issue:
+    if: github.event.issue.state == 'open'
     name: Ensure Terms of Service are accepted
     runs-on: ubuntu-latest
     permissions:
       issues: write
     outputs:
-        accepted: ${{ steps.are_tos_accepted.outputs.accepted }}
+      accepted: ${{ steps.set-output.outputs.accepted }}
     steps:
       - name: Run /validate command
         if: github.event_name == 'issue_comment'
@@ -39,27 +39,27 @@ jobs:
         uses: zentered/issue-forms-body-parser@v1.5.1
 
       - name: Find TOS checkbox state
-        id: are_tos_accepted
+        id: set-output
         run: |
-          echo "accepted=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["terms-of-services"].list[0].checked' )" >> $GITHUB_OUTPUT
+          accepted=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["terms-of-services"].list[0].checked' )
+          echo $accepted
+          if [[ accepted == '' || accepted == 'null' ]]; then
+            echo "No checkbox for the tos found in the body of the issue ${{ inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
+            echo "Is the \"terms-of-services\" field present?" >> $GITHUB_STEP_SUMMARY
+            echo ${{ steps.parse.outputs.data }} >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+          echo "accepted=$accepted" >> $GITHUB_OUTPUT
 
-      - name: Remove 'tos/accepted' label
-        if: steps.are_tos_accepted.outputs.accepted == 'false'
-        run: |
-          gh issue edit ${{ github.event.issue.number }} --remove-label tos/accepted
-          gh issue edit ${{ github.event.issue.number }} --add-label tos/not-accepted
-
-      - name: Add 'tos/accepted' label
-        if: steps.are_tos_accepted.outputs.accepted == 'true'
-        run: |
-          gh issue edit ${{ github.event.issue.number }} --add-label tos/accepted
-          gh issue edit ${{ github.event.issue.number }} --remove-label tos/not-accepted
-
+  tos-not-accepted:
+    runs-on: ubuntu-latest
+    needs: [parse-issue]
+    if: needs.parse-issue.outputs.accepted == 'false'
+    steps:
       - uses: actions/checkout@v3
 
-      - name: Render template when tos are not accepted
-        id: template_tos_not_accepted
-        if: steps.are_tos_accepted.outputs.accepted == 'false'
+      - name: Render template
+        id: render
         uses: chuhlomin/render-template@v1.6
         with:
           template: .github/workflows/templates/tos-not-accepted.md
@@ -67,17 +67,29 @@ jobs:
             workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             user: ${{ github.event.issue.user.login}}
 
-      - name: Add Comment if tos not accepted
-        if: steps.are_tos_accepted.outputs.accepted == 'false'
+      - name: Add comment
+        if: env.ACT == true && steps.are_tos_accepted.outputs.accepted == 'false'
         uses: peter-evans/create-or-update-comment@v2
         with:
           edit-mode: replace
           issue-number: ${{ github.event.issue.number }}
-          body: ${{ steps.template_tos_not_accepted.outputs.result }}
+          body: ${{ steps.render.outputs.result }}
 
-      - name: Render template when tos are accepted
-        id: template_tos_accepted
-        if: steps.are_tos_accepted.outputs.accepted == 'true'
+      - name: Remove 'tos/accepted' label
+        if: steps.are_tos_accepted.outputs.accepted == 'false'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} --remove-label tos/accepted
+          gh issue edit ${{ github.event.issue.number }} --add-label tos/not-accepted
+
+  tos-accepted:
+    runs-on: ubuntu-latest
+    needs: [ parse-issue ]
+    if: needs.parse-issue.outputs.accepted == 'true'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Render template
+        id: render
         uses: chuhlomin/render-template@v1.6
         with:
           template: .github/workflows/templates/tos-accepted.md
@@ -85,13 +97,26 @@ jobs:
             workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
             user: ${{ github.event.issue.user.login}}
 
-      - name: Add Comment if tos accepted
-        if: steps.are_tos_accepted.outputs.accepted == 'true'
+      - name: Add comment
+        if: env.ACT == true && steps.are_tos_accepted.outputs.accepted == 'true'
         uses: peter-evans/create-or-update-comment@v2
         with:
           edit-mode: replace
           issue-number: ${{ github.event.issue.number }}
           body: ${{ steps.template_tos_accepted.outputs.result }}
+
+      - name: Add 'tos/accepted' label
+        if: steps.are_tos_accepted.outputs.accepted == 'true'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} --add-label tos/accepted
+          gh issue edit ${{ github.event.issue.number }} --remove-label tos/not-accepted
+
+  tos-not-found:
+    runs-on: ubuntu-latest
+    needs: [ parse-issue ]
+    if: needs.parse-issue.outputs.accepted == 'null'
+    steps:
+      - uses: actions/checkout@v3
 
       - name: Render template when tos are not found
         id: template_tos_not_found
@@ -103,15 +128,18 @@ jobs:
             workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Add comment if tos not found
-        if: steps.are_tos_accepted.outputs.accepted == 'null'
+        if: env.ACT == true && steps.are_tos_accepted.outputs.accepted == 'null'
         uses: peter-evans/create-or-update-comment@v2
         with:
           edit-mode: replace
           issue-number: ${{ github.event.issue.number }}
           body: ${{ steps.template_tos_not_found.outputs.result }}
 
+      - name: Mark job as failed
+        run: exit 1
+
   validate:
     name: Extension validation
-    needs: check
-    if: needs.check.outputs.accepted == 'true'
+    needs: parse-issue
+    if: needs.parse-issue.outputs.accepted == 'true'
     uses: ./.github/workflows/validation.yaml

--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -42,14 +42,18 @@ jobs:
         id: set-output
         run: |
           accepted=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["terms-of-services"].list[0].checked' )
-          echo $accepted
-          if [[ accepted == '' || accepted == 'null' ]]; then
+          echo "accepted=$accepted" >> $GITHUB_OUTPUT
+
+      - name: Validate tos
+        if: steps.set-output.outputs.accepted == 'null'
+        run: |
+          # Check if $GITHUB_STEP_SUMMARY exist o avoid the following lines to error when running with act
+          if [[ -w "$GITHUB_STEP_SUMMARY" ]]; then
             echo "No checkbox for the tos found in the body of the issue ${{ inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
             echo "Is the \"terms-of-services\" field present?" >> $GITHUB_STEP_SUMMARY
             echo ${{ steps.parse.outputs.data }} >> $GITHUB_STEP_SUMMARY
-            exit 1
           fi
-          echo "accepted=$accepted" >> $GITHUB_OUTPUT
+          exit 1
 
   tos-not-accepted:
     runs-on: ubuntu-latest
@@ -114,7 +118,7 @@ jobs:
   tos-not-found:
     runs-on: ubuntu-latest
     needs: [ parse-issue ]
-    if: needs.parse-issue.outputs.accepted == 'null'
+    if: failure()
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -37,17 +37,28 @@ jobs:
           body-includes: ${{ github.workflow}} workflow has started
           direction: last
 
-      - name: Get Date
-        id: get-date
-        run: |
-          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-        shell: bash
-
       - name: Redirect api.segment.io to localhost
         id: redirect-segment
         run: |
           echo '127.0.0.2 api.segment.io' | sudo tee -a /etc/hosts
           cat /etc/hosts
+
+      - name: Download appcast
+        run: |
+          curl https://prod-docker-desktop.s3.amazonaws.com/mac/main/amd64/appcast.xml -o appcast.xml
+
+      - name: Get Docker Desktop latest build url
+        uses: mavrosxristoforos/get-xml-info@1.1.1
+        id: get-build-url
+        with:
+          xml-path: appcast.xml
+          xpath: //channel/link
+
+      - name: Get Docker Desktop latest build number
+        id: get-build-number
+        run: |
+          build=$(echo ${{ steps.get-build-url.outputs.result }} | sed -E 's/.*\/([0-9]+)\/.*/\1/')
+          echo "build=$build" >> $GITHUB_OUTPUT
 
       - name: Get Docker app cache
         id: cache-docker-desktop-app
@@ -56,7 +67,7 @@ jobs:
           cache-name: cache-docker-desktop-app
         with:
           path: /Applications/Docker.app
-          key: docker-desktop-app-mac-amd64-${{ steps.get-date.outputs.date }}
+          key: docker-desktop-app-mac-amd64-${{ steps.get-build-number.outputs.build }}
 
       - name: Get Docker install settings cache
         id: cache-docker-desktop-install-settings
@@ -65,7 +76,7 @@ jobs:
           cache-name: cache-docker-desktop-install-settings
         with:
           path: ./cache/desktopInstallSettings/
-          key: docker-desktop-install-settings-mac-${{ steps.get-date.outputs.date }}
+          key: docker-desktop-install-settings-mac-${{ steps.get-build-number.outputs.build }}
 
       - name: Copy Desktop install settings in /Library
         if: steps.cache-docker-desktop-install-settings.outputs.cache-hit == 'true'
@@ -83,7 +94,7 @@ jobs:
           sw_vers
           mkdir ./temp
           mkdir ./mount
-          wget -q -O ./temp/DockerDesktop.dmg https://desktop.docker.com/mac/main/amd64/Docker.dmg
+          wget -q -O ./temp/DockerDesktop.dmg ${{ steps.get-build-url.outputs.result }}
           /usr/bin/hdiutil attach -noverify ./temp/DockerDesktop.dmg -mountpoint ./mount/desktop -nobrowse
           echo "dmg mounted"
           sudo ./mount/desktop/Docker.app/Contents/MacOS/install --accept-license

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -11,32 +11,33 @@ jobs:
   parse-issue:
     runs-on: ubuntu-latest
     outputs:
-      repository: ${{ steps.parse.outputs.repository }}
+      repository: ${{ steps.set-output.outputs.repository }}
     steps:
       - name: Parse issue body
         id: parse
         uses: zentered/issue-forms-body-parser@v1.5.1
 
       - name: Find extension repository
-        id: parse-repository
+        id: set-output
         run: |
           repository=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["docker-hub-repository-name"].text' )
           echo "repository=$repository" >> $GITHUB_OUTPUT
-          
-          if [[ $repository == null ]]; then
-            # Check if $GITHUB_STEP_SUMMARY exist o avoid the following lines to error when running with act
-            if [[ -w "$GITHUB_STEP_SUMMARY" ]]; then
-              echo "No repository found in the body of the issue ${{ inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
-              echo "Is the \"docker-hub-repository-name\" field present?" >> $GITHUB_STEP_SUMMARY
-              echo ${{ steps.parse.outputs.data }} >> $GITHUB_STEP_SUMMARY
-            fi
-            exit 1
+
+      - name: Validate repository
+        if: steps.set-output.outputs.repository == 'null'
+        run: |
+          # Check if $GITHUB_STEP_SUMMARY exist o avoid the following lines to error when running with act
+          if [[ -w "$GITHUB_STEP_SUMMARY" ]]; then
+            echo "No repository found in the body of the issue ${{ inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
+            echo "Is the \"docker-hub-repository-name\" field present?" >> $GITHUB_STEP_SUMMARY
+            echo ${{ steps.parse.outputs.data }} >> $GITHUB_STEP_SUMMARY
           fi
+          exit 1
 
   error:
     runs-on: ubuntu-latest
     needs: parse-issue
-    if: failure() && needs.parse-issue.outputs.repository == null
+    if: failure()
     steps:
       - uses: actions/checkout@v3
 
@@ -59,17 +60,26 @@ jobs:
         run: exit 1
 
   noop-validate:
-    if: env.ACT
+    if: github.event.act == true
     runs-on: ubuntu-latest
     needs: parse-issue
     outputs:
       validation_output: ${{ steps.set-output.outputs.validation_output }}
     steps:
       - id: set-output
-        run: echo "validation_output=No errors" >> $GITHUB_OUTPUT
+        run: |
+          if [[ ${TEST_VALIDATION_FAILED} ]]; then
+            echo "validation_output=There are errors" >> $GITHUB_OUTPUT
+            exit 1
+          fi
+          if [[ ${TEST_VALIDATION_ERRORED} ]]; then
+            # Do not set the validation_output variable on failure
+            exit 1
+          fi
+          echo "validation_output=No errors" >> $GITHUB_OUTPUT
 
   validate:
-    if: !env.ACT
+    if: github.event.act == false
     name: Validate extension
     runs-on: macOS-latest
     needs: parse-issue
@@ -183,11 +193,8 @@ jobs:
 
   validation-succeeded:
     runs-on: ubuntu-latest
-    needs: [parse-issue, validate, noop-validate]
-    # always() make sure the job is run even if the noop-validate or validate jobs are skipped
-    if: |
-      always()
-      && (needs.validate.result == 'success' || needs.noop-validate.result== 'success')
+    needs: [parse-issue, noop-validate, validate]
+    if: always() && (needs.validate.result == 'success' || needs.noop-validate.result == 'success')
     steps:
       - uses: actions/checkout@v3
 
@@ -216,8 +223,11 @@ jobs:
 
   validation-failed:
     runs-on: ubuntu-latest
-    needs: [parse-issue, validate, noop-validate]
-    if: needs.validate.result != 'success' ||  needs.noop-validate.result != 'success'
+    needs: [parse-issue, noop-validate, validate]
+    if: |
+      always() &&
+      (needs.validate.result == 'failure' && needs.validate.outputs.validation_output != '') ||
+      (needs.noop-validate.result == 'failure' && needs.noop-validate.outputs.validation_output != '')
     steps:
       - uses: actions/checkout@v3
 
@@ -248,8 +258,11 @@ jobs:
 
   validation-errored:
     runs-on: ubuntu-latest
-    needs: [validate, noop-validate]
-    if: needs.validate.result == 'failure' || needs.noop-validate.result == 'failure'
+    needs: [noop-validate, validate]
+    if: |
+      always() &&
+      (needs.validate.result == 'failure' && needs.validate.outputs.validation_output == '') ||
+      (needs.noop-validate.result == 'failure' && needs.noop-validate.outputs.validation_output == '')
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -8,35 +8,74 @@ env:
   GH_REPO: ${{ github.repository }}
 
 jobs:
-  pre:
-    if: github.event.issue.closed == false
-    name: Prepare validation
+  parse-issue:
     runs-on: ubuntu-latest
     outputs:
-      tos_accepted: ${{ steps.checks.outputs.tos_accepted }}
+      repository: ${{ steps.parse.outputs.repository }}
     steps:
-      - id: checks
-        run: |
-          labels=$(gh issue view ${{ github.event.issue.number }} --json labels --jq '[.labels[].name]')
-          echo "tos_accepted=$(echo $labels | jq '. | index("tos/accepted") != null' )" >> $GITHUB_OUTPUT
+      - name: Parse issue body
+        id: parse
+        uses: zentered/issue-forms-body-parser@v1.5.1
 
-  validate:
-    name: Validate extension
-    runs-on: macOS-latest
-    needs: pre
-    if: |
-      needs.pre.outputs.tos_accepted == 'true'
+      - name: Find extension repository
+        id: parse-repository
+        run: |
+          repository=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["docker-hub-repository-name"].text' )
+          echo "repository=$repository" >> $GITHUB_OUTPUT
+          
+          if [[ $repository == null ]]; then
+            # Check if $GITHUB_STEP_SUMMARY exist o avoid the following lines to error when running with act
+            if [[ -w "$GITHUB_STEP_SUMMARY" ]]; then
+              echo "No repository found in the body of the issue ${{ inputs.issue_number }}" >> $GITHUB_STEP_SUMMARY
+              echo "Is the \"docker-hub-repository-name\" field present?" >> $GITHUB_STEP_SUMMARY
+              echo ${{ steps.parse.outputs.data }} >> $GITHUB_STEP_SUMMARY
+            fi
+            exit 1
+          fi
+
+  error:
+    runs-on: ubuntu-latest
+    needs: parse-issue
+    if: failure() && needs.parse-issue.outputs.repository == null
     steps:
-      - name: Find eventual initial comment
-        uses: peter-evans/find-comment@v2.1.0
-        id: fc
-        continue-on-error: true
+      - uses: actions/checkout@v3
+
+      - name: Render template
+        id: render
+        uses: chuhlomin/render-template@v1.6
+        with:
+          template: .github/workflows/templates/validation-repository-not-found.md
+          vars: |
+            workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Add comment
+        if: env.ACT == false # do not comment when running with act
+        uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.issue.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: ${{ github.workflow}} workflow has started
-          direction: last
+          body: ${{ steps.render.outputs.result }}
 
+      - name: Mark job as failed
+        run: exit 1
+
+  noop-validate:
+    if: env.ACT
+    runs-on: ubuntu-latest
+    needs: parse-issue
+    outputs:
+      validation_output: ${{ steps.set-output.outputs.validation_output }}
+    steps:
+      - id: set-output
+        run: echo "validation_output=No errors" >> $GITHUB_OUTPUT
+
+  validate:
+    if: !env.ACT
+    name: Validate extension
+    runs-on: macOS-latest
+    needs: parse-issue
+    outputs:
+      validation_output: ${{ steps.validate.outputs.validation_output }}
+    steps:
       - name: Redirect api.segment.io to localhost
         id: redirect-segment
         run: |
@@ -124,110 +163,116 @@ jobs:
           until docker ps; do echo "ps failed, sleep 10 s and try again"; sleep 10; done
           echo "Docker started and ready"
 
-      - name: Parse issue body
-        id: parse
-        uses: zentered/issue-forms-body-parser@v1.5.1
-
-      - name: Find extension repository
-        id: parse-repository
-        run: |
-          echo "repository=$(echo '${{ steps.parse.outputs.data }}' | jq -r '.["docker-hub-repository-name"].text' )" >> $GITHUB_OUTPUT
-
       - name: Validate extension
         id: validate
         continue-on-error: true
         run: |
           touch output.txt
-          docker extension validate -a -s -i ${{ steps.parse-repository.outputs.repository }} &> output.txt
+          docker extension validate -a -s -i ${{ needs.parse-issue.outputs.repository }} &> output.txt
 
       - name: Read validation output
-        run: |          
+        run: |
           delimiter=$(uuidgen)
-          
-          echo "VALIDATION_OUTPUT<<$delimiter" >> $GITHUB_ENV
-          cat output.txt >> $GITHUB_ENV
-          echo "$delimiter" >> $GITHUB_ENV
+          echo "validation_output=<<$delimiter" >> $GITHUB_OUTPUT
+          cat output.txt >> $GITHUB_OUTPUT
+          echo "$delimiter" >> $GITHUB_OUTPUT
 
+      - name: Mark jobs as failed
+        if: ${{ steps.validate.outcome }} == 'failure'
+        run: exit 1
+
+  validation-succeeded:
+    runs-on: ubuntu-latest
+    needs: [parse-issue, validate, noop-validate]
+    # always() make sure the job is run even if the noop-validate or validate jobs are skipped
+    if: |
+      always()
+      && (needs.validate.result == 'success' || needs.noop-validate.result== 'success')
+    steps:
       - uses: actions/checkout@v3
 
-      - name: Add Comment if validation succeeded
-        if: steps.validate.outcome == 'success'
+      - name: Render template
+        id: render
+        uses: chuhlomin/render-template@v1.6
+        with:
+          template: .github/workflows/templates/validation-succeeded.md
+          vars: |
+            workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            extension: ${{ needs.parse-issue.outputs.repository }}
+            validation_output: ${{ needs.validate.outputs.validation_output || needs.noop-validate.outputs.validation_output }}
+
+      - name: Add Comment
+        if: env.ACT == false
         uses: peter-evans/create-or-update-comment@v2
         with:
-          edit-mode: replace
           issue-number: ${{ github.event.issue.number }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            :white_check_mark: Validation ended successfully
+          body: ${{ steps.render.outputs.result }}
 
-            Yay! The extension [${{ steps.parse-repository.outputs.repository }}](https://open.docker.com/extensions/marketplace?extensionId=${{ steps.parse-repository.outputs.repository }}) is valid :tada:.
-
-            Now, @docker/extensions will add the `publish/ready` label to the issue which will start the publishing of the extension on the marketplace.
-            Once published, this issue will be closed :smile:.
-
-            In the meantime, you can answer a couple of questions to tell us how your experience building a Docker Desktop extension was :smiley:: https://forms.gle/88SLHsn2Xb1BgMQ49.
-
-
-            <details>
-            <summary>Click to see the validation output</summary>
-
-            > ${{ env.VALIDATION_OUTPUT }}
-            </details>
-
-            ---
-            See [action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
-
-      - name: Add 'validation/succeeded' label
-        if: steps.validate.outcome == 'success'
+      - name: Update labels
+        if: env.ACT == false
         run: |
           gh issue edit ${{ github.event.issue.number }} --remove-label "validation/failed"
           gh issue edit ${{ github.event.issue.number }} --add-label "validation/succeeded"
 
-      - name: Remove 'validation/succeeded' label
-        if: steps.validate.outcome != 'success'
+  validation-failed:
+    runs-on: ubuntu-latest
+    needs: [parse-issue, validate, noop-validate]
+    if: needs.validate.result != 'success' ||  needs.noop-validate.result != 'success'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Render template
+        id: render
+        uses: chuhlomin/render-template@v1.6
+        with:
+          template: .github/workflows/templates/validation-failed.md
+          vars: |
+            workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            validation_output: ${{ needs.validate.outputs.validation_output || needs.noop-validate.outputs.validation_output }}
+
+      - name: Add comment
+        if: env.ACT == false # do not comment when running with act
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.issue.number }}
+          body: ${{ steps.render.outputs.result }}
+
+      - name: Update labels
+        if: env.ACT == false
         run: |
           gh issue edit ${{ github.event.issue.number }} --remove-label "validation/succeeded"
           gh issue edit ${{ github.event.issue.number }} --add-label "validation/failed"
 
-      - name: Add Comment if validation failed
-        if: steps.validate.outcome != 'success'
+      - name: Mark job as failed
+        run: exit 1
+
+  validation-errored:
+    runs-on: ubuntu-latest
+    needs: [validate, noop-validate]
+    if: needs.validate.result == 'failure' || needs.noop-validate.result == 'failure'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Render template
+        id: render
+        uses: chuhlomin/render-template@v1.6
+        with:
+          template: .github/workflows/templates/validation-errored.md
+          vars: |
+            workflow_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            validation_output: ${{ needs.validate.outputs.validation_output || needs.noop-validate.outputs.validation_output }}
+
+      - name: Add comment
+        if: env.ACT == false # do not comment when running with act
         uses: peter-evans/create-or-update-comment@v2
         with:
-          edit-mode: replace
           issue-number: ${{ github.event.issue.number }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            :x: Validation failed with the following errors
+          body: ${{ steps.render.outputs.result }}
 
-            > ${{ env.VALIDATION_OUTPUT }}
-
-            Please fix the issues and comment with `/validate` to re-run the validation when you are ready.
-
-            ---
-            See [action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
-
-      - name: Add Comment if job failed
-        if: failure()
-        uses: peter-evans/create-or-update-comment@v2
-        with:
-          edit-mode: replace
-          issue-number: ${{ github.event.issue.number }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            :x: There was a problem during the validation job.
-
-            Someone from the @docker/extensions will have to take a look at this issue.
-            We will let you know in this issue when it is fixed.
-
-            ---
-            See [action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.
-
-
-      - name: Add 'docker/validation-errored' label if job failed
-        if: failure()
+      - name: Add 'docker/validation-errored' label
+        if: env.ACT == false
         run: |
           gh issue edit ${{ github.event.issue.number }} --add-label "docker/validation-errored"
 
       - name: Mark job as failed
-        if: steps.validate.outcome != 'success'
         run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1532 @@
+{
+  "name": "test",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "bats": "github:bats-core/bats-core#master",
+        "bats-assert": "https://github.com/bats-core/bats-assert",
+        "bats-support": "https://github.com/bats-core/bats-support"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true
+    },
+    "node_modules/backoff": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+      "integrity": "sha512-ljr33cUQ/vyXE/60QuRO+WKGW4PzQ5OTWNXPWQwOTx5gh43q0pZocaVyXoU2gvFtasMIdIohdm9s01qoT6IJBQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/base64id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "integrity": "sha512-DSjtfjhAsHl9J4OJj7e4+toV2zqxJrGwVd3CLlsCp8QmicvOn7irG0Mb8brOc/nur3SdO8lIbNlY1s1ZDJdUKQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/bats": {
+      "version": "1.8.2",
+      "resolved": "git+ssh://git@github.com/bats-core/bats-core.git#5a47c79364490c4af72ca0b7784ddca1b11c6054",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
+      }
+    },
+    "node_modules/bats-assert": {
+      "version": "2.1.0",
+      "resolved": "git+ssh://git@github.com/bats-core/bats-assert.git#db015db5edfd788301d42eda0348301d9893a3b8",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "verbose": "^0.2.3"
+      },
+      "peerDependencies": {
+        "bats": "0.4 || ^1",
+        "bats-support": "^0.3"
+      }
+    },
+    "node_modules/bats-support": {
+      "version": "0.3.0",
+      "resolved": "git+ssh://git@github.com/bats-core/bats-support.git#3c8fadc5097c9acfc96d836dced2bb598e48b009",
+      "dev": true,
+      "license": "CC0-1.0",
+      "peerDependencies": {
+        "bats": "0.4 || ^1"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.x"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz",
+      "integrity": "sha512-2vIZf67+gMicLu8McscD1NNhMWbiTSJkhlByoTA1Gw54zOb/9IlxylYG+Kr9z1X2wZTHh1AMSp+YiMjYtLkVUA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/duplex-emitter": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/duplex-emitter/-/duplex-emitter-2.1.2.tgz",
+      "integrity": "sha512-s+wsVSzINBF0hT0tzurKclyxLQY7GOagdHg4caz+xJoK8q1yBt0fXJYe/zcgg/RBXkkCEwQKWZ3fUl+ot3hP4A==",
+      "dev": true,
+      "dependencies": {
+        "split": "~0.2.6",
+        "stream-combiner": "0.0.2",
+        "through": "~2.3.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/duplexer": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+      "integrity": "sha512-nO0WWuIDTde3CWK/8IPpG50dyhUilgpsqzYSIP+w20Yh+4iDgb/2Gs75QItcp0Hmx/JtxtTXBalj+LSTD1VemA==",
+      "dev": true
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/emitter": {
+      "version": "1.0.1",
+      "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+      "integrity": "sha512-k3Da+QreMb9waaGCHNAHox5QqxnZEYlQmvIVYwQibrI6OpIRyIIyFGgDV5dXRLr1AJ32JLqEh0VxQEq20dFskw==",
+      "dev": true,
+      "dependencies": {
+        "indexof": "0.0.1"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-0.7.12.tgz",
+      "integrity": "sha512-+Szdw1zSAxDslm2M16lL/yEuKc1YE251i3Zg057GR+2XR0PbSlhMOoPZ6KpfVOma9rrYvFaXHf+7H5O7BhW5ZQ==",
+      "dev": true,
+      "dependencies": {
+        "base64id": "0.1.0",
+        "debug": "0.6.0",
+        "engine.io-parser": "0.3.0",
+        "ws": "0.4.31"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-0.7.12.tgz",
+      "integrity": "sha512-RQHdq5vqNRYwcW4EBYgKOYbDgzM5x0BP6ZUh/k1vugWmddFyFeLezAIbDB204oRDmqwccxwERkSQCtqfqDa+rw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "0.7.2",
+        "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+        "engine.io-parser": "0.3.0",
+        "global": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+        "has-cors": "https://github.com/component/has-cors/archive/v1.0.2.tar.gz",
+        "indexof": "0.0.1",
+        "ws": "0.4.31",
+        "xmlhttprequest": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.2.tgz",
+      "integrity": "sha512-Ch0X6QrHzrNiWwLsBJj9KgXL5IK67pfDyTsXXVPyrdObVyKuj/rPdCtZg761nHZM1GQ7wW/o9cAZf5JeTN/vRg==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-0.3.0.tgz",
+      "integrity": "sha512-1KWn0iXSA5T0JFl9/JkxO75Ww8bELAehfH716cUt5+d1R2g0d05nkxvQLmnuBEN7fQJQWyhfO/cQsbjvMYT9Ag==",
+      "dev": true
+    },
+    "node_modules/engine.io-stream": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/engine.io-stream/-/engine.io-stream-0.4.3.tgz",
+      "integrity": "sha512-Q+V/2W9YV3c3UoOLXHQhEz1cCEb32ewYlLajmBA4r7Epg/MbTnam5RsdGDyVQZNN5+HFbGd5n7ulQkYOtYM5NQ==",
+      "dev": true,
+      "dependencies": {
+        "engine.io": "0.7.12",
+        "engine.io-client": "0.7.12"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/global": {
+      "version": "2.0.1",
+      "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+      "integrity": "sha512-O91OcV/NbdmQJPHaRu2ekSP7bqFRLWgqSwaJvqHPZHUwmHBagQYTOra29+LnzzG3lZkXH1ANzHzfCxtAPM9HMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-cors": {
+      "version": "1.0.2",
+      "resolved": "https://github.com/component/has-cors/archive/v1.0.2.tar.gz",
+      "integrity": "sha512-mRFI0KYjdxHUuiVNncS42nzgFekJkW5svmMzFFFxAwwcbzbkrpzoSEL5F2s0hNt194rGw5ELKqGujwrC4m9jPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
+    "node_modules/invert-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/invert-stream/-/invert-stream-0.0.1.tgz",
+      "integrity": "sha512-fA2WMc53mUmf+cnIlnUZ944QDXXRwWzlGHHAiZw0IC25Afzel81BS5ixgnoOJYzDVxtTL0haGPM9CXpBN5BOjQ==",
+      "dev": true
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/nan": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+      "integrity": "sha512-V9/Pyy5Oelv6vVJP9X+dAzU3IO19j6YXrJnODHxP2h54hTvfFQGahdsQV6Ule/UukiEJk1SkQ/aUyWUm61RBQw==",
+      "dev": true
+    },
+    "node_modules/node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==",
+      "deprecated": "Use uuid module instead",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/reconnect": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/reconnect/-/reconnect-2.0.2.tgz",
+      "integrity": "sha512-s5HHdwaVW261ecXm9wgRs3VWYaHeP08rclE/SaomdvTZLH+Qba/s/lZWNk5hagkkNGL4NB7kYDD4HP7HCirAPQ==",
+      "dev": true,
+      "dependencies": {
+        "engine.io-stream": "~0.4.2",
+        "reconnect-core": "~0.2.1",
+        "request": ">=2.12 <3"
+      },
+      "optionalDependencies": {
+        "shoe": ">=0.0.7 <1",
+        "sockjs-stream": ">=1 <2"
+      }
+    },
+    "node_modules/reconnect-core": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-0.2.2.tgz",
+      "integrity": "sha512-aa5osv0tDSAoXt9FEkbSmDdOiFdTqx7Gseey+pna2XZNqHQ28nGKgMl1iDYWOwGAQ1nq3rd3inQ+zPn6dv+BHA==",
+      "dev": true,
+      "dependencies": {
+        "backoff": "~2.3.0"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dev": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/shoe": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.15.tgz",
+      "integrity": "sha512-XM5aTvK9kzdYYYZ0sr4pqteQ1jeHucXgSa6ueQE7CrDZTa+1bXGbQWT5EPyIw4LYhZ0fur43cGZgnifJJPfSOQ==",
+      "bundleDependencies": [
+        "sockjs-client"
+      ],
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "sockjs": "0.3.7"
+      }
+    },
+    "node_modules/shoe/node_modules/sockjs-client": {
+      "version": "0.0.0-unreleasable",
+      "extraneous": true,
+      "inBundle": true
+    },
+    "node_modules/sockjs": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz",
+      "integrity": "sha512-Hhb9Z0yY5QWc4rSXcGgByUhijT/adjyL6SpoLeZgXbpa8rd2s9Dbr1voP/8eeLDYET4AHTffPxz4kgJQH8WwrA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "faye-websocket": "0.4.4",
+        "node-uuid": "1.3.3"
+      }
+    },
+    "node_modules/sockjs/node_modules/node-uuid": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz",
+      "integrity": "sha512-xKQtL5imfvX6PvUmgJyU/XaNT/l8tKvs+sJ6KLOmIzk/H8+sm7uE80QlPmmu3l1uirvRL3kZqtJPWoQBWT9gQw==",
+      "deprecated": "Use uuid module instead",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==",
+      "dev": true,
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.2.tgz",
+      "integrity": "sha512-Z2D5hPQapscuHNqiyUgjnF1sxG/9CB7gs1a9vcS2/OvMiFwmm6EZw9IjbU34l5mPXS62RidpoBdyB83E0GXHLw==",
+      "dev": true,
+      "dependencies": {
+        "duplexer": "~0.0.3"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "node_modules/tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/verbose": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/verbose/-/verbose-0.2.3.tgz",
+      "integrity": "sha512-083yQcZh4P9X8cUL7EnjVjIyfqWz7KfkMGDJfDP8Tic5O4xlHEfmmNQGxdH+iHbJbugyLPZnHENoM5T3zlSOoA==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.1"
+      ],
+      "dependencies": {
+        "duplex-emitter": "*",
+        "invert-stream": "*",
+        "node-uuid": "*",
+        "propagate": "*",
+        "reconnect": "*"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "node_modules/verror/node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true
+    },
+    "node_modules/ws": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+      "integrity": "sha512-mWiVQ9qZGPXvLxQ4xGy58Ix5Bw0L99SB+hDT8L59bty4fbnQczaGl4YEWR7AzLQGbvPn/30r9/o41dPiSuUmYw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "commander": "~0.6.1",
+        "nan": "~0.3.0",
+        "options": ">=0.0.5",
+        "tinycolor": "0.x"
+      },
+      "bin": {
+        "wscat": "bin/wscat"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xmlhttprequest": {
+      "version": "1.5.0",
+      "resolved": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
+      "integrity": "sha512-TVSZwoeUQ7OKhb8jnQdSxGFz+lm4MGWmhG0deeYg85VQT74x5LcSrKeXHE0ZIzEycgqQ5mF8r8e1AykA7TpNAQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  },
+  "dependencies": {
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
+      "dev": true
+    },
+    "backoff": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz",
+      "integrity": "sha512-ljr33cUQ/vyXE/60QuRO+WKGW4PzQ5OTWNXPWQwOTx5gh43q0pZocaVyXoU2gvFtasMIdIohdm9s01qoT6IJBQ==",
+      "dev": true
+    },
+    "base64id": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz",
+      "integrity": "sha512-DSjtfjhAsHl9J4OJj7e4+toV2zqxJrGwVd3CLlsCp8QmicvOn7irG0Mb8brOc/nur3SdO8lIbNlY1s1ZDJdUKQ==",
+      "dev": true
+    },
+    "bats": {
+      "version": "git+ssh://git@github.com/bats-core/bats-core.git#5a47c79364490c4af72ca0b7784ddca1b11c6054",
+      "dev": true,
+      "from": "bats@https://github.com/bats-core/bats-core#master"
+    },
+    "bats-assert": {
+      "version": "git+ssh://git@github.com/bats-core/bats-assert.git#db015db5edfd788301d42eda0348301d9893a3b8",
+      "dev": true,
+      "from": "bats-assert@https://github.com/bats-core/bats-assert",
+      "requires": {
+        "verbose": "^0.2.3"
+      }
+    },
+    "bats-support": {
+      "version": "git+ssh://git@github.com/bats-core/bats-support.git#3c8fadc5097c9acfc96d836dced2bb598e48b009",
+      "dev": true,
+      "from": "bats-support@https://github.com/bats-core/bats-support",
+      "requires": {}
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
+    "commander": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+      "integrity": "sha512-0fLycpl1UMTGX257hRsu/arL/cUbcvQM4zMKwvLvzXtfdezIV4yotPS2dYtknF+NmEfWSoCEF6+hj9XLm/6hEw==",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "debug": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz",
+      "integrity": "sha512-2vIZf67+gMicLu8McscD1NNhMWbiTSJkhlByoTA1Gw54zOb/9IlxylYG+Kr9z1X2wZTHh1AMSp+YiMjYtLkVUA==",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true
+    },
+    "duplex-emitter": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/duplex-emitter/-/duplex-emitter-2.1.2.tgz",
+      "integrity": "sha512-s+wsVSzINBF0hT0tzurKclyxLQY7GOagdHg4caz+xJoK8q1yBt0fXJYe/zcgg/RBXkkCEwQKWZ3fUl+ot3hP4A==",
+      "dev": true,
+      "requires": {
+        "split": "~0.2.6",
+        "stream-combiner": "0.0.2",
+        "through": "~2.3.4"
+      }
+    },
+    "duplexer": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.0.4.tgz",
+      "integrity": "sha512-nO0WWuIDTde3CWK/8IPpG50dyhUilgpsqzYSIP+w20Yh+4iDgb/2Gs75QItcp0Hmx/JtxtTXBalj+LSTD1VemA==",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "emitter": {
+      "version": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+      "integrity": "sha512-k3Da+QreMb9waaGCHNAHox5QqxnZEYlQmvIVYwQibrI6OpIRyIIyFGgDV5dXRLr1AJ32JLqEh0VxQEq20dFskw==",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "engine.io": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-0.7.12.tgz",
+      "integrity": "sha512-+Szdw1zSAxDslm2M16lL/yEuKc1YE251i3Zg057GR+2XR0PbSlhMOoPZ6KpfVOma9rrYvFaXHf+7H5O7BhW5ZQ==",
+      "dev": true,
+      "requires": {
+        "base64id": "0.1.0",
+        "debug": "0.6.0",
+        "engine.io-parser": "0.3.0",
+        "ws": "0.4.31"
+      }
+    },
+    "engine.io-client": {
+      "version": "0.7.12",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-0.7.12.tgz",
+      "integrity": "sha512-RQHdq5vqNRYwcW4EBYgKOYbDgzM5x0BP6ZUh/k1vugWmddFyFeLezAIbDB204oRDmqwccxwERkSQCtqfqDa+rw==",
+      "dev": true,
+      "requires": {
+        "debug": "0.7.2",
+        "emitter": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
+        "engine.io-parser": "0.3.0",
+        "global": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+        "has-cors": "https://github.com/component/has-cors/archive/v1.0.2.tar.gz",
+        "indexof": "0.0.1",
+        "ws": "0.4.31",
+        "xmlhttprequest": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.2.tgz",
+          "integrity": "sha512-Ch0X6QrHzrNiWwLsBJj9KgXL5IK67pfDyTsXXVPyrdObVyKuj/rPdCtZg761nHZM1GQ7wW/o9cAZf5JeTN/vRg==",
+          "dev": true
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-0.3.0.tgz",
+      "integrity": "sha512-1KWn0iXSA5T0JFl9/JkxO75Ww8bELAehfH716cUt5+d1R2g0d05nkxvQLmnuBEN7fQJQWyhfO/cQsbjvMYT9Ag==",
+      "dev": true
+    },
+    "engine.io-stream": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/engine.io-stream/-/engine.io-stream-0.4.3.tgz",
+      "integrity": "sha512-Q+V/2W9YV3c3UoOLXHQhEz1cCEb32ewYlLajmBA4r7Epg/MbTnam5RsdGDyVQZNN5+HFbGd5n7ulQkYOtYM5NQ==",
+      "dev": true,
+      "requires": {
+        "engine.io": "0.7.12",
+        "engine.io-client": "0.7.12"
+      }
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "dev": true
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "faye-websocket": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.4.4.tgz",
+      "integrity": "sha512-78pqrJbvGZSe8i+PLsPd+aJqTyGqgyWLnMw5NOwtXCTVMzEFh1zQPwIuIL/ycTj4rkDy5zZ9B6frYPqVPJBzyQ==",
+      "dev": true,
+      "optional": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "global": {
+      "version": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+      "integrity": "sha512-O91OcV/NbdmQJPHaRu2ekSP7bqFRLWgqSwaJvqHPZHUwmHBagQYTOra29+LnzzG3lZkXH1ANzHzfCxtAPM9HMA==",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
+    },
+    "has-cors": {
+      "version": "https://github.com/component/has-cors/archive/v1.0.2.tar.gz",
+      "integrity": "sha512-mRFI0KYjdxHUuiVNncS42nzgFekJkW5svmMzFFFxAwwcbzbkrpzoSEL5F2s0hNt194rGw5ELKqGujwrC4m9jPw==",
+      "dev": true,
+      "requires": {
+        "global": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg==",
+      "dev": true
+    },
+    "invert-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/invert-stream/-/invert-stream-0.0.1.tgz",
+      "integrity": "sha512-fA2WMc53mUmf+cnIlnUZ944QDXXRwWzlGHHAiZw0IC25Afzel81BS5ixgnoOJYzDVxtTL0haGPM9CXpBN5BOjQ==",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "dev": true
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      }
+    },
+    "mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.52.0"
+      }
+    },
+    "nan": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz",
+      "integrity": "sha512-V9/Pyy5Oelv6vVJP9X+dAzU3IO19j6YXrJnODHxP2h54hTvfFQGahdsQV6Ule/UukiEJk1SkQ/aUyWUm61RBQw==",
+      "dev": true
+    },
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha512-TkCET/3rr9mUuRp+CpO7qfgT++aAxfDRaalQhwPFzI9BY/2rCDn6OfpZOVggi1AXfTPpfkTrg5f5WQx5G1uLxA==",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
+    "options": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+      "integrity": "sha512-bOj3L1ypm++N+n7CEbbe473A414AB7z+amKYshRb//iuL3MpdDCLhPnw6aVTdKB9g5ZRVHIEp8eUln6L2NUStg==",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
+    },
+    "psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "dev": true
+    },
+    "reconnect": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/reconnect/-/reconnect-2.0.2.tgz",
+      "integrity": "sha512-s5HHdwaVW261ecXm9wgRs3VWYaHeP08rclE/SaomdvTZLH+Qba/s/lZWNk5hagkkNGL4NB7kYDD4HP7HCirAPQ==",
+      "dev": true,
+      "requires": {
+        "engine.io-stream": "~0.4.2",
+        "reconnect-core": "~0.2.1",
+        "request": ">=2.12 <3",
+        "shoe": ">=0.0.7 <1",
+        "sockjs-stream": ">=1 <2"
+      }
+    },
+    "reconnect-core": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reconnect-core/-/reconnect-core-0.2.2.tgz",
+      "integrity": "sha512-aa5osv0tDSAoXt9FEkbSmDdOiFdTqx7Gseey+pna2XZNqHQ28nGKgMl1iDYWOwGAQ1nq3rd3inQ+zPn6dv+BHA==",
+      "dev": true,
+      "requires": {
+        "backoff": "~2.3.0"
+      }
+    },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "shoe": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/shoe/-/shoe-0.0.15.tgz",
+      "integrity": "sha512-XM5aTvK9kzdYYYZ0sr4pqteQ1jeHucXgSa6ueQE7CrDZTa+1bXGbQWT5EPyIw4LYhZ0fur43cGZgnifJJPfSOQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "sockjs": "0.3.7"
+      },
+      "dependencies": {
+        "sockjs-client": {
+          "version": "0.0.0-unreleasable",
+          "bundled": true,
+          "extraneous": true
+        }
+      }
+    },
+    "sockjs": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.7.tgz",
+      "integrity": "sha512-Hhb9Z0yY5QWc4rSXcGgByUhijT/adjyL6SpoLeZgXbpa8rd2s9Dbr1voP/8eeLDYET4AHTffPxz4kgJQH8WwrA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "faye-websocket": "0.4.4",
+        "node-uuid": "1.3.3"
+      },
+      "dependencies": {
+        "node-uuid": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.3.3.tgz",
+          "integrity": "sha512-xKQtL5imfvX6PvUmgJyU/XaNT/l8tKvs+sJ6KLOmIzk/H8+sm7uE80QlPmmu3l1uirvRL3kZqtJPWoQBWT9gQw==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
+    "split": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.2.10.tgz",
+      "integrity": "sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
+    "sshpk": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.17.0.tgz",
+      "integrity": "sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.2.tgz",
+      "integrity": "sha512-Z2D5hPQapscuHNqiyUgjnF1sxG/9CB7gs1a9vcS2/OvMiFwmm6EZw9IjbU34l5mPXS62RidpoBdyB83E0GXHLw==",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.0.3"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "dev": true
+    },
+    "tinycolor": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz",
+      "integrity": "sha512-+CorETse1kl98xg0WAzii8DTT4ABF4R3nquhrkIbVGcw1T8JYs5Gfx9xEfGINPUZGDj9C4BmOtuKeaTtuuRolg==",
+      "dev": true
+    },
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "verbose": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/verbose/-/verbose-0.2.3.tgz",
+      "integrity": "sha512-083yQcZh4P9X8cUL7EnjVjIyfqWz7KfkMGDJfDP8Tic5O4xlHEfmmNQGxdH+iHbJbugyLPZnHENoM5T3zlSOoA==",
+      "dev": true,
+      "requires": {
+        "duplex-emitter": "*",
+        "invert-stream": "*",
+        "node-uuid": "*",
+        "propagate": "*",
+        "reconnect": "*"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "dependencies": {
+        "core-util-is": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+          "dev": true
+        }
+      }
+    },
+    "ws": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+      "integrity": "sha512-mWiVQ9qZGPXvLxQ4xGy58Ix5Bw0L99SB+hDT8L59bty4fbnQczaGl4YEWR7AzLQGbvPn/30r9/o41dPiSuUmYw==",
+      "dev": true,
+      "requires": {
+        "commander": "~0.6.1",
+        "nan": "~0.3.0",
+        "options": ">=0.0.5",
+        "tinycolor": "0.x"
+      }
+    },
+    "xmlhttprequest": {
+      "version": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
+      "integrity": "sha512-TVSZwoeUQ7OKhb8jnQdSxGFz+lm4MGWmhG0deeYg85VQT74x5LcSrKeXHE0ZIzEycgqQ5mF8r8e1AykA7TpNAQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "bats tests.bats"
+  },
+  "devDependencies": {
+    "bats": "github:bats-core/bats-core#master",
+    "bats-assert": "https://github.com/bats-core/bats-assert",
+    "bats-support": "https://github.com/bats-core/bats-support"
+  }
+}

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,23 @@
+# How to test the workflows locally?
+
+## Prerequisites
+
+You must install [act](https://github.com/nektos/act)
+
+## Run the workflows locally
+
+The test folder contains json files for each scenario you want to test. 
+You can run any of the scenarios by running the following command:
+
+```bash
+act <event> -e test/<scenario>.json
+```
+
+## Use tests.bats
+
+You can also run tests using [bats](https://github.com/bats-core/bats-core).
+
+```node
+npm install
+npm run test
+```

--- a/test/issue_comment/with_command.json
+++ b/test/issue_comment/with_command.json
@@ -1,0 +1,12 @@
+{
+  "act": true,
+  "action": "created",
+  "comment": {
+    "body": "/validate"
+  },
+  "issue":{
+    "state": "open",
+    "number": 1,
+    "body": "### Docker Hub repository name\n\nbenjaming/extension-builder-extension\n\n### Terms of services\n\n- [X] I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)"
+  }
+}

--- a/test/issue_comment/with_command_on_closed_issue.json
+++ b/test/issue_comment/with_command_on_closed_issue.json
@@ -1,0 +1,12 @@
+{
+  "act": true,
+  "action": "created",
+  "comment": {
+    "body": "/validate"
+  },
+  "issue":{
+    "state": "closed",
+    "number": 1,
+    "body": "### Docker Hub repository name\n\nbenjaming/extension-builder-extension\n\n### Terms of services\n\n- [X] I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)"
+  }
+}

--- a/test/issues/no_repository.json
+++ b/test/issues/no_repository.json
@@ -1,0 +1,10 @@
+{
+  "act": true,
+  "issue":{
+    "state": "open",
+    "body": "### Terms of services\n\n- [x] I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)",
+    "user": {
+      "login": "benjaming"
+    }
+  }
+}

--- a/test/issues/no_tos.json
+++ b/test/issues/no_tos.json
@@ -1,0 +1,10 @@
+{
+  "act": true,
+  "issue":{
+    "state": "open",
+    "body": "### Docker Hub repository name\n\nbenjaming/extension-builder-extension",
+    "user": {
+      "login": "benjaming"
+    }
+  }
+}

--- a/test/issues/tos_accepted.json
+++ b/test/issues/tos_accepted.json
@@ -1,0 +1,11 @@
+{
+  "act": true,
+  "issue":{
+    "state": "open",
+    "number": 1,
+    "body": "### Docker Hub repository name\n\nbenjaming/extension-builder-extension\n\n### Terms of services\n\n- [X] I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)",
+    "user": {
+      "login": "benjaming"
+    }
+  }
+}

--- a/test/issues/tos_not_accepted.json
+++ b/test/issues/tos_not_accepted.json
@@ -1,0 +1,10 @@
+{
+  "act": true,
+  "issue":{
+    "state": "open",
+    "body": "### Docker Hub repository name\n\nbenjaming/extension-builder-extension\n\n### Terms of services\n\n- [ ] I accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/)",
+    "user": {
+      "login": "benjaming"
+    }
+  }
+}

--- a/tests.bats
+++ b/tests.bats
@@ -1,0 +1,81 @@
+setup() {
+    load 'node_modules/bats-support/load'
+    load 'node_modules/bats-assert/load'
+}
+
+@test "validation succeeded" {
+    run act issues -e test/issues/tos_accepted.json \
+        --container-architecture linux/amd64
+
+    assert_line '[validate/Extension validation/validation-succeeded] 🏁  Job succeeded'
+    refute_line --partial 'validation-failed'
+    refute_line --partial 'validation-error'
+    assert_success
+}
+
+@test "validation failed" {
+    run act issues -e test/issues/tos_accepted.json \
+        --env TEST_VALIDATION_FAILED=true \
+        --container-architecture linux/amd64
+
+    assert_line '[validate/Extension validation/validation-failed   ]   ❌  Failure - Main Mark job as failed'
+    refute_line --partial 'validation-succeeded'
+    refute_line --partial 'validation-error'
+    assert_failure
+}
+
+@test "validation errored" {
+    run act issues -e test/issues/tos_accepted.json \
+        --env TEST_VALIDATION_ERRORED=true \
+        --container-architecture linux/amd64
+
+    assert_line '[validate/Extension validation/validation-errored  ]   ❌  Failure - Main Mark job as failed'
+    refute_line --partial 'validation-succeeded'
+    refute_line --partial 'validation-failed'
+    assert_failure
+}
+
+@test "do not validate extension when tos are not accepted" {
+    run act issues -e test/issues/tos_not_accepted.json \
+        --container-architecture linux/amd64
+
+    assert_line '[TOS Check/tos-not-accepted                    ] 🏁  Job succeeded'
+    assert_success
+}
+
+@test "do not validate extension when tos are missing" {
+    run act issues -e test/issues/no_tos.json \
+        --container-architecture linux/amd64
+
+    assert_line '[TOS Check/Ensure Terms of Service are accepted]   ❌  Failure - Main Validate tos'
+    assert_line '[TOS Check/tos-not-found                       ]   ❌  Failure - Main Mark job as failed'
+    assert_failure
+}
+
+@test "do not validate extension when repository is missing" {
+    run act issues -e test/issues/no_repository.json \
+        --container-architecture linux/amd64
+
+    assert_line '[validate/Extension validation/parse-issue]   ❌  Failure - Main Validate repository'
+    assert_line '[validate/Extension validation/error             ]   ❌  Failure - Main Mark job as failed'
+    assert_failure
+}
+
+@test "validate extension when comment contains /validate" {
+    run act issue_comment -e test/issue_comment/with_command.json \
+        --container-architecture linux/amd64
+
+    assert_line '[TOS Check/Ensure Terms of Service are accepted]   ✅  Success - Main Run /validate command'
+    assert_line '[validate/Extension validation/validation-succeeded] 🏁  Job succeeded'
+    refute_line --partial 'validation-failed'
+    refute_line --partial 'validation-error'
+    assert_success
+}
+
+@test "do not validate extension when comment contains /validate on a closed issue" {
+    run act issue_comment -e test/issue_comment/with_command_on_closed_issue.json \
+        --container-architecture linux/amd64
+
+    refute_output
+    assert_success
+}


### PR DESCRIPTION
This PR does three things:
- it caches Docker Desktop per release ([3050dcb](https://github.com/docker/extensions-submissions/pull/3/commits/3050dcb37a365ae6e92da0844f2570d2413bb091))
- it refactors the workflows to use templates for comments everywhere
- it adds some "tests" that use [act](https://github.com/nektos/act) and [bats](https://github.com/bats-core/bats-core)

<img width="684" alt="Screenshot 2023-01-20 at 00 32 55" src="https://user-images.githubusercontent.com/212269/213585411-e9c5fc88-cadf-4f2f-bf89-14ef0768f60f.png">

Note: you should read this PR commit per commit