### PR TITLE
Prevent concurrent job per issue

### DIFF
--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -15,6 +15,10 @@ env:
   GH_TOKEN: ${{ github.token }}
   GH_REPO: ${{ github.repository }}
 
+concurrency:
+  group: submission-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   parse-issue:
     if: github.event.issue.state == 'open'

--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -148,6 +148,9 @@ jobs:
         run: exit 1
 
   validate:
+    concurrency:
+      group: submission-${{ github.event.issue.number }}
+      cancel-in-progress: true
     name: Extension validation
     needs: parse-issue
     if: needs.parse-issue.outputs.accepted == 'true'


### PR DESCRIPTION
A new job is created each time the issue is updated (title and body) or a comment is created.
To avoid this the running job must be canceled.

<img width="3008" alt="Screenshot 2023-01-23 at 11 56 45" src="https://user-images.githubusercontent.com/212269/214023302-246479b1-c44a-4484-8d34-95b06750119c.png">

- https://github.com/benja-M-1/github-experiment/issues/63
- https://github.com/benja-M-1/github-experiment/actions

I will make another PR to prevent sending a comment for the tos acceptance, is the last message is already the same (but with another date) 
