### PR TITLE
Remove concurrency config for now

### DIFF
--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -140,9 +140,6 @@ jobs:
         run: exit 1
 
   validate:
-    concurrency:
-      group: submission-${{ github.event.issue.number }}
-      cancel-in-progress: true
     name: Extension validation
     needs: parse-issue
     if: needs.parse-issue.outputs.accepted == 'true'

--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -15,10 +15,6 @@ env:
   GH_TOKEN: ${{ github.token }}
   GH_REPO: ${{ github.repository }}
 
-concurrency:
-  group: submission-${{ github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
   parse-issue:
     if: github.event.issue.state == 'open'


### PR DESCRIPTION
The concurrency group was configured to not run a same job in parallel for the same submission. The concurrency group name was based on the issue number contained in payload of the event that triggered the build. Since the workflow is triggered only by events related to issues and issue_comments, they should all have the issue number. However, it turns our that the value is empty. Thus any new issue or validation would cancel the previous one.

I haven't figured out why yet. I will open a discussion on the github action discussion repo because I don't see why is this happening...
