### PR TITLE
Make links opened in a new tab

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_automatic_review.yaml
+++ b/.github/ISSUE_TEMPLATE/1_automatic_review.yaml
@@ -25,7 +25,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        :warning: We automatically validate the greatest [semver](https://semver.org/){:target="_blank"} tag available on Docker Hub. See [the documentation](https://docs.docker.com/desktop/extensions-sdk/extensions/DISTRIBUTION/#release-your-extension) for more details.
+        :warning: We automatically validate the greatest [semver](https://semver.org/){:target="_blank"} tag available on Docker Hub. See [the documentation](https://docs.docker.com/desktop/extensions-sdk/extensions/DISTRIBUTION/#release-your-extension){:target="_blank"} for more details.
   - type: checkboxes
     attributes:
       label: Terms of services


### PR DESCRIPTION
This PR make the links in the issue form to be opened in a new tab to not mess with the publisher workflow

