### PR TITLE
Do not add any label or message if the tos are already accepted

### DIFF
--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -91,7 +91,7 @@ jobs:
   tos-accepted:
     runs-on: ubuntu-latest
     needs: [ parse-issue ]
-    if: needs.parse-issue.outputs.accepted == 'true'
+    if: needs.parse-issue.outputs.accepted == 'true' && !contains(github.event.issue.labels.*.name, 'tos/accepted')
     steps:
       - uses: actions/checkout@v3
 
@@ -116,7 +116,7 @@ jobs:
         run: gh issue edit ${{ github.event.issue.number }} --remove-label tos/not-accepted
 
       - name: Add 'tos/accepted' label
-        if: env.ACT == false && !contains(github.event.issue.labels.*.name, 'tos/accepted')
+        if: env.ACT == false
         run: gh issue edit ${{ github.event.issue.number }} --add-label tos/accepted
 
   tos-not-found:


### PR DESCRIPTION
When the issue already has the tos/accepted label, it is not necessary to add it again.
Otherwise, the user will see the following weird sequence of messages
- bot: tos accepted
- bot: validation failed
- user: /validate
- bot: tos accepted
- bot: validation succeeded

Instead they will see:
- bot: tos accepted
- bot: validation failed
- user: /validate
- bot: validation succeeded
