### PR TITLE
Make links in comments to open in a new tab

### DIFF
--- a/.github/workflows/templates/tos-not-accepted.md
+++ b/.github/workflows/templates/tos-not-accepted.md
@@ -1,3 +1,3 @@
 :x: Terms of Service not accepted yet.
 
-@{{ .user }} to proceed with the submission of your extension you must accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/).
+@{{ .user }} to proceed with the submission of your extension you must accept the [term of services](https://www.docker.com/legal/extensions_marketplace_developer_agreement/){:target="_blank"}.

--- a/.github/workflows/templates/validation-failed.md
+++ b/.github/workflows/templates/validation-failed.md
@@ -10,4 +10,4 @@ docker extension validate -a -s -i {{ .extension }}
 
 Then you can trigger the validation commenting `/validate` when you are ready.
 
-See https://docs.docker.com/desktop/extensions-sdk/extensions/validate/ for more information.
+See [https://docs.docker.com/desktop/extensions-sdk/extensions/validate/](https://docs.docker.com/desktop/extensions-sdk/extensions/validate/){:target="_blank"} for more information.

--- a/.github/workflows/templates/validation-succeeded.md
+++ b/.github/workflows/templates/validation-succeeded.md
@@ -1,9 +1,9 @@
-:white_check_mark: The extension [{{ .extension }}](https://open.docker.com/extensions/marketplace?extensionId={{ .extension }}) is valid :tada:.
+:white_check_mark: The extension [{{ .extension }}](https://open.docker.com/extensions/marketplace?extensionId={{ .extension }}){:target="_blank"} is valid :tada:.
 
 Now, @docker/extensions will authorise the publication of the extension to the marketplace.
 Once the extension is published, this issue will be closed.
 
-In the meantime, please tell us about your experience building a Docker Desktop extension here: https://survey.alchemer.com/s3/7184948/Publishers-Feedback-Form.
+In the meantime, please tell us about your experience building a Docker Desktop extension here: [https://survey.alchemer.com/s3/7184948/Publishers-Feedback-Form](https://survey.alchemer.com/s3/7184948/Publishers-Feedback-Form){:target="_blank"}.
 
 <details>
 <summary>Click to see the validation output</summary>


### PR DESCRIPTION
I made links in the template to open a new tab in https://github.com/docker/extensions-submissions/pull/37. Here the changes apply to the links in the comments.