### PR TITLE
Add --error-only option to the validate command

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -188,7 +188,7 @@ jobs:
         continue-on-error: true
         run: |
           touch output.txt
-          docker extension validate -a -s -i ${{ needs.parse-issue.outputs.repository }} &> output.txt
+          docker extension validate --auto-resolve-tag --errors-only --sdk-compatibility --validate-install-uninstall ${{ needs.parse-issue.outputs.repository }} &> output.txt
 
       - name: Read validation output
         id: set-output


### PR DESCRIPTION
This PR introduce the new `--error-only` option of the validate command to improve the output.

See the result here: https://github.com/benja-M-1/github-experiment/issues/68#issuecomment-1447951195
