### PR TITLE
Generate the share link to always have a valid link

### DIFF
--- a/.github/workflows/templates/validation-succeeded.md
+++ b/.github/workflows/templates/validation-succeeded.md
@@ -1,13 +1,6 @@
-:white_check_mark: The extension [{{ .extension }}](https://open.docker.com/extensions/marketplace?extensionId={{ .extension }}) is valid :tada:.
+:white_check_mark: The extension [{{ .extension }}]({{ .share_link }}) is valid :tada:.
 
 Now, @docker/extensions will authorise the publication of the extension to the marketplace.
 Once the extension is published, this issue will be closed.
 
 In the meantime, please tell us about your experience building a Docker Desktop extension here: https://survey.alchemer.com/s3/7184948/Publishers-Feedback-Form.
-
-<details>
-<summary>Click to see the validation output</summary>
-
-> {{ .validation_output }}
-
-</details>

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -95,6 +95,7 @@ jobs:
     needs: parse-issue
     outputs:
       validation_output: ${{ steps.set-output.outputs.validation_output }}
+      share_link: ${{ steps.share-link.outputs.share-link }}
     steps:
       - name: Redirect api.segment.io to localhost
         id: redirect-segment
@@ -202,6 +203,11 @@ jobs:
         if: steps.validate.outcome != 'success'
         run: exit 1
 
+      - name: Generate share link
+        id: share-link
+        run: |
+          echo "share-link=$(docker extension share ${{ needs.parse-issue.outputs.repository }})" >> $GITHUB_OUTPUT
+
   validation-succeeded:
     runs-on: ubuntu-latest
     needs: [parse-issue, noop-validate, validate]
@@ -216,7 +222,7 @@ jobs:
           template: .github/workflows/templates/validation-succeeded.md
           vars: |
             extension: ${{ needs.parse-issue.outputs.repository }}
-            validation_output: ${{ toJSON(format('{0}{1}', needs.validate.outputs.validation_output, needs.noop-validate.outputs.validation_output)) }}
+            share_link: ${{ needs.validate.outputs.share_link }}
 
       - name: Add Comment
         if: env.ACT == false


### PR DESCRIPTION
When the validation passes, the message contains a link to the extension in the marketplace within DD that does not work.
With this PR, the link is generated by the cli and is working, see https://github.com/benja-M-1/github-experiment/issues/63#issuecomment-1452059980
