### PR TITLE
Need to add `always` to run validate

### DIFF
--- a/.github/workflows/tos.yaml
+++ b/.github/workflows/tos.yaml
@@ -173,5 +173,5 @@ jobs:
   validate:
     name: Extension validation
     needs: parse-issue
-    if: needs.parse-issue.outputs.accepted == 'true'
+    if: always() && needs.parse-issue.outputs.accepted == 'true'
     uses: ./.github/workflows/validation.yaml


### PR DESCRIPTION
While trying to fix the tests locally, I discovered that the `always` expression is needed to start the validate job. It is needed because its `needs` tree contains a job that has is not executed and thus not mark as `successful` 