### PR TITLE
Allow to specify an build url to use in env vars in case there's a problem with the latest build

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -124,10 +124,15 @@ jobs:
 
       - name: Get Docker Desktop latest build url
         uses: mavrosxristoforos/get-xml-info@1.1.1
-        id: get-build-url
+        id: get-latest-build-url
         with:
           xml-file: appcast.xml
           xpath: //channel/link
+
+      - name: Define the build URL to use
+        id: get-build-url
+        run:
+          echo "info=${{ env.DD_BUILD_URL || steps.get-latest-build-url.outputs.info }}" >> $GITHUB_OUTPUT
 
       - name: Get Docker Desktop latest build number
         id: get-build-number


### PR DESCRIPTION
See slack https://docker.slack.com/archives/C05RB76E6Q3/p1696008358837159
