### PR TITLE
Fix extension validation

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -106,7 +106,7 @@ jobs:
 
   validate:
     if: github.event.act == false
-    runs-on: ubuntu22_16cores_64gb
+    runs-on: ubuntu-latest
     needs: parse-issue
     environment: production
     outputs:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -103,7 +103,6 @@ jobs:
             exit 1
           fi
 
-
   validate:
     if: github.event.act == false
     runs-on: ubuntu-latest
@@ -113,12 +112,17 @@ jobs:
       validation_output: ${{ steps.set-output.outputs.validation_output }}
       share_link: ${{ steps.share-link.outputs.share-link }}
     steps:
-      - uses: docker/desktop-action/start@v0.3.0
+      - if: ${{ vars.DOCKER_DESKTOP_BUILD_URL != '' }}
+        run: echo "Docker Desktop build URL ${{ vars.DOCKER_DESKTOP_BUILD_URL }}" >> $GITHUB_STEP_SUMMARY
+
+      - uses: docker/desktop-action/start@v0.3.6
         with:
           docker-desktop-build-url: ${{ vars.DOCKER_DESKTOP_BUILD_URL || 'latest' }}
 
-      - if: ${{ vars.DOCKER_DESKTOP_BUILD_URL != '' }}
-        run: echo "Docker Desktop build URL ${{ vars.DOCKER_DESKTOP_BUILD_URL }}" >> $GITHUB_STEP_SUMMARY
+      - name: Change Desktop settings and allow installing non marketplace extensions
+        run: |
+          jq '.onlyMarketplaceExtensions|=false' ~/.docker/desktop/settings.json >./new-settings.json
+          mv -f ./new-settings.json ~/.docker/desktop/settings.json
 
       - name: Validate extension
         id: validate
@@ -252,7 +256,6 @@ jobs:
       - name: Add 'docker/validation-errored' label
         if: env.ACT == false && contains(github.event.issue.labels.*.name, 'docker/validation-errored')
         run: gh issue edit ${{ github.event.issue.number }} --add-label "docker/validation-errored"
-
 
       - name: Mark job as failed
         run: exit 1


### PR DESCRIPTION
Latest Docker Desktop default settings do not allow installing non marketplace extensions. We need to change settings before installing the extension to validate

cf https://github.com/docker/extensions-submissions/pull/159