### PR TITLE
fix: use variable for regex in share link validation

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -156,7 +156,8 @@ jobs:
           REPOSITORY: ${{ needs.parse-issue.outputs.repository }}
         run: |
           share_link=$(docker extension share "$REPOSITORY")
-          if [[ ! "$share_link" =~ ^https://[a-zA-Z0-9./?=_&%-]+$ ]]; then
+          url_regex='^https://[a-zA-Z0-9./?=_&%-]+$'
+          if [[ ! "$share_link" =~ $url_regex ]]; then
             echo "Unexpected share link format" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- The `Generate share link` step in the validation workflow was failing with `syntax error in conditional expression: unexpected token '&'`
- The `&` character in the regex pattern caused bash to error when used directly in `[[ =~ ]]`
- Fix: store the regex in a variable and reference it unquoted, which is the correct bash idiom for `=~` matching